### PR TITLE
FIFO Success Test 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,12 +315,9 @@ pub fn select_coin_fifo(
 
     for (index, inputs) in sorted_inputs {
         estimated_fees = calculate_fee(accumulated_weight, options.target_feerate);
-        println!("estimated fees {}", estimated_fees);
-        println!("input {}", inputs.value);
         let outter = (options.target_value
             + estimated_fees.max(options.min_absolute_fee)
             + options.min_drain_value);
-        println!("estimated target {}", outter);
 
         if accumulated_value
             >= (options.target_value
@@ -332,10 +329,7 @@ pub fn select_coin_fifo(
         accumulated_value += inputs.value;
         accumulated_weight += inputs.weight;
         selected_inputs.push(index);
-        println!("accumulated value {}", accumulated_value);
-
     }
-    println!("accumulated weight {}", accumulated_weight);
     if accumulated_value
         < (options.target_value
             + estimated_fees.max(options.min_absolute_fee)
@@ -698,14 +692,13 @@ mod test {
     }
 
     fn fifo_setup_output_groups(
-        value_sequence: Vec<(u64,u32)>,
+        value_sequence: Vec<(u64, u32)>,
         weight: u32,
         target_feerate: f32,
     ) -> Vec<OutputGroup> {
         let mut inputs: Vec<OutputGroup> = Vec::new();
         for (value, sequence) in value_sequence.into_iter() {
             // input value = effective value + fees
-            // Example If we want our input to be equal to 1 CENT while being considered by knapsack(effective value), we have to increase the input by the fees to beginwith
             let value: u64 = value.saturating_add(calculate_fee(weight, target_feerate));
             inputs.push(OutputGroup {
                 value,
@@ -1263,19 +1256,26 @@ mod test {
         let mut options = setup_options(1300);
         options.min_absolute_fee = 0;
         options.min_drain_value = 0;
-        options.excess_strategy = ExcessStrategy::ToRecipient;
-        let special_inputs = vec![(300,3), (400,5), (500,4), (600, 2), (700, 1), (800,6)];
+        options.excess_strategy = ExcessStrategy::ToDrain;
+
+        // Case 1: Single  input is selected
+        let special_inputs = vec![(300, 3), (400, 5), (500, 4), (600, 2), (1300, 1), (800, 6)];
         let inputs = fifo_setup_output_groups(special_inputs, 10, options.target_feerate);
-        let select_coin_result = select_coin(&inputs, options);
+        let select_coin_result: Result<SelectionOutput, SelectionError> =
+            select_coin(&inputs, options);
         let fifo_result = select_coin_fifo(&inputs, options);
-        assert!(select_coin_result.is_ok());
-        assert!(fifo_result.is_ok());
         let fifo_output = fifo_result.unwrap();
         let select_coin_output = select_coin_result.unwrap();
-        println!("{:?}", fifo_output.selected_inputs);
-        println!("{:?}", select_coin_output.selected_inputs);
         assert_eq!(fifo_output.waste.0, select_coin_output.waste.0);
-        // let selection_output = result.unwrap();
-        // assert!(!selection_output.selected_inputs.is_empty());
+
+        // Case 2: Multiple inputs are selected
+        let special_inputs = vec![(300, 3), (400, 5), (500, 4), (600, 2), (700, 1), (800, 6)];
+        let inputs = fifo_setup_output_groups(special_inputs, 10, options.target_feerate);
+        let select_coin_result: Result<SelectionOutput, SelectionError> =
+            select_coin(&inputs, options);
+        let fifo_result = select_coin_fifo(&inputs, options);
+        let fifo_output = fifo_result.unwrap();
+        let select_coin_output = select_coin_result.unwrap();
+        assert_eq!(fifo_output.waste.0, select_coin_output.waste.0);
     }
 }


### PR DESCRIPTION
### Objective 

Theoretically, a coin select algorithm should be selected as the best candidate by the **select_coin** function,  if it produced the minimum amount of waste. Verification of the expected behaviour is needed with the help a crafted inputs that are biased towards a specific coin_select algorithm.

### Changes
 - Added a `test_select_coin_fifo_successful` unit test function to validate the correcteness of  FIFO algorithm
 - Added a generator function to specifically create **FIFO output groups** from vectors.

### Scope Of Change
This is a semi critical change because the test is expected to acts a verifier of the **coin-select** and **FIFO**  logic, such test logic should therefore be correct.