### PR TITLE
no std Feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,6 +71,7 @@ dependencies = [
 name = "rust-coinselect"
 version = "0.1.0"
 dependencies = [
+ "libm",
  "rand",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = { version = "0.8.5", default-features = false , features = ["alloc"] }
+rand = { version = "0.8.5", features = ["small_rng"], default-features = false }
+libm = { version = "0.2.8", default-features = false }
 
-
-#Empty default feature set, (helpful to generalise in github actions)
 [features]
-std = ["rand/std"]
+std = ["rand/std", "rand/std_rng"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.5"
+rand = { version = "0.8.5", default-features = false , features = ["alloc"] }
 
 
 #Empty default feature set, (helpful to generalise in github actions)
 [features]
-default = []
+std = ["rand/std"]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate alloc;
 use alloc::vec;
 use alloc::vec::{Vec};
 use core::num;
-use std::rc;
 use alloc::collections::BTreeSet;
 use core::cmp::Reverse;
 use libm::ceil;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,17 @@
 #![allow(unused)]
+#![no_std]
 
 //! A blockchain-agnostic Rust Coinselection library
 
 use rand::{seq::SliceRandom, thread_rng, Rng};
-use std::cmp::Reverse;
-use std::collections::HashSet;
+extern crate alloc;
+use alloc::vec;
+use alloc::vec::{Vec};
+use core::num;
+use alloc::collections::BTreeSet;
+use core::cmp::Reverse;
 use std::hash::{Hash, Hasher};
+
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -151,7 +157,7 @@ pub fn select_coin_knapsack(
 /// smaller_coins should be sorted in descending order based on the value of the OutputGroup, and every OutputGroup value should be less than adjusted_target
 fn calculate_accumulated_weight(
     smaller_coins: &[(usize, EffectiveValue, Weight)],
-    selected_inputs: &HashSet<usize>,
+    selected_inputs: &BTreeSet<usize>,
 ) -> u32 {
     let mut accumulated_weight: u32 = 0;
     for &(index, _value, weight) in smaller_coins {
@@ -168,9 +174,9 @@ fn knap_sack(
     inputs: &[OutputGroup],
     options: CoinSelectionOpt,
 ) -> Result<SelectionOutput, SelectionError> {
-    let mut selected_inputs: HashSet<usize> = HashSet::new();
+    let mut selected_inputs: BTreeSet<usize> = BTreeSet::new();
     let mut accumulated_value: u64 = 0;
-    let mut best_set: HashSet<usize> = HashSet::new();
+    let mut best_set: BTreeSet<usize> = BTreeSet::new();
     let mut best_set_value: u64 = u64::MAX;
     let mut rng = thread_rng();
     for i in 1..=1000 {
@@ -511,6 +517,7 @@ fn calculate_waste(
 #[inline]
 fn calculate_fee(weight: u32, rate: f32) -> u64 {
     (weight as f32 * rate).ceil() as u64
+    num::
 }
 
 /// Returns the effective value which is the actual value minus the estimated fee of the OutputGroup


### PR DESCRIPTION
## Objective 
no_std environments are environments such as embedded devices with no access to the std library feature, which could mean having no access to **Os threads**, Os random number generator and other utilities that depends on Os specific functionalities. Having proper support for no_std can significantly expand the usability of the library.

## Changes
- Changed the default environment to be **no_std**
- Added **std** specific library function call `select_coin_threaded`
- Added specific test to ensure it works well

## Scope
The scope is critical as it affects the usability of the library

close #36 