### PR TITLE
Refactor/remove is segwit field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1144,10 +1144,10 @@ mod test {
         let mut selected_input_2: Vec<usize> = Vec::new();
         for j in 0..RUN_TESTS {
             if let Ok(result) = select_coin_knapsack(&inputs, options) {
-                selected_input_1 = result.selected_inputs.clone();
+                selected_input_1.clone_from(&result.selected_inputs);
             }
             if let Ok(result) = select_coin_knapsack(&inputs, options) {
-                selected_input_2 = result.selected_inputs.clone();
+                selected_input_2.clone_from(&result.selected_inputs);
             }
             // Checking if the selected inputs, in two consequtive calls of the knapsack function are not the same
             assert_ne!(selected_input_1, selected_input_2);
@@ -1175,10 +1175,10 @@ mod test {
         for k in 0..RUN_TESTS {
             for l in 0..RANDOM_REPEATS {
                 if let Ok(result) = select_coin_knapsack(&inputs, options) {
-                    selected_input_1 = result.selected_inputs.clone();
+                    selected_input_1.clone_from(&result.selected_inputs);
                 }
                 if let Ok(result) = select_coin_knapsack(&inputs, options) {
-                    selected_input_2 = result.selected_inputs.clone();
+                    selected_input_2.clone_from(&result.selected_inputs);
                 }
                 if selected_input_1 == selected_input_2 {
                     fails += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ pub fn select_coin_fifo(
     let mut estimated_fees: u64 = 0;
 
     // Sorting the inputs vector based on creation_sequence
-    let mut inputs_with_sequence: Vec<_> = inputs
+    let mut sorted_inputs: Vec<_> = inputs
         .iter()
         .enumerate()
         .filter(|(_, og)| og.creation_sequence.is_some())
@@ -318,11 +318,7 @@ pub fn select_coin_fifo(
         .filter(|(_, og)| og.creation_sequence.is_none())
         .collect();
 
-    inputs_with_sequence.sort_by_key(|(_, a)| a.creation_sequence);
-
-    let mut sorted_inputs = Vec::new();
-    sorted_inputs.append(&mut inputs_without_sequence);
-    sorted_inputs.append(&mut inputs_with_sequence);
+    sorted_inputs.extend(inputs_without_sequence);
 
     for (index, inputs) in sorted_inputs {
         estimated_fees = calculate_fee(accumulated_weight, options.target_feerate);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,10 +306,23 @@ pub fn select_coin_fifo(
     let mut estimated_fees: u64 = 0;
 
     // Sorting the inputs vector based on creation_sequence
+    let mut inputs_with_sequence: Vec<_> = inputs
+        .iter()
+        .enumerate()
+        .filter(|(_, og)| og.creation_sequence.is_some())
+        .collect();
 
-    let mut sorted_inputs: Vec<_> = inputs.iter().enumerate().collect();
+    let mut inputs_without_sequence: Vec<_> = inputs
+        .iter()
+        .enumerate()
+        .filter(|(_, og)| og.creation_sequence.is_none())
+        .collect();
 
-    sorted_inputs.sort_by_key(|(_, a)| a.creation_sequence);
+    inputs_with_sequence.sort_by_key(|(_, a)| a.creation_sequence);
+
+    let mut sorted_inputs = Vec::new();
+    sorted_inputs.append(&mut inputs_without_sequence);
+    sorted_inputs.append(&mut inputs_with_sequence);
 
     for (index, inputs) in sorted_inputs {
         estimated_fees = calculate_fee(accumulated_weight, options.target_feerate);
@@ -578,6 +591,13 @@ mod test {
                 input_count: 1,
                 is_segwit: false,
                 creation_sequence: Some(1001),
+            },
+            OutputGroup {
+                value: 1500,
+                weight: 150,
+                input_count: 1,
+                is_segwit: false,
+                creation_sequence: None,
             },
         ]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub struct CoinSelectionOpt {
 pub enum ExcessStrategy {
     ToFee,
     ToRecipient,
-    ToDrain,
+    ToChange,
 }
 
 /// Error Describing failure of a selection attempt, on any subset of inputs.
@@ -667,11 +667,11 @@ fn calculate_waste(
         waste = (accumulated_weight as f32 * (options.target_feerate - long_term_feerate)).ceil()
             as u64;
     }
-    if options.excess_strategy != ExcessStrategy::ToDrain {
+    if options.excess_strategy != ExcessStrategy::ToChange {
         // Change is not created if excess strategy is ToFee or ToRecipient. Hence cost of change is added
         waste += (accumulated_value - (options.target_value + estimated_fee));
     } else {
-        // Change is created if excess strategy is set to ToDrain. Hence 'excess' should be set to 0
+        // Change is created if excess strategy is set to ToChange. Hence 'excess' should be set to 0
         waste += options.change_cost;
     }
     waste
@@ -857,7 +857,7 @@ mod test {
             cost_per_input: 20,
             cost_per_output: 10,
             min_change_value: 500,
-            excess_strategy: ExcessStrategy::ToDrain,
+            excess_strategy: ExcessStrategy::ToChange,
         }
     }
     fn knapsack_setup_options(adjusted_target: u64, target_feerate: f32) -> CoinSelectionOpt {
@@ -876,7 +876,7 @@ mod test {
             cost_per_input: 20,
             cost_per_output: 10,
             min_change_value,
-            excess_strategy: ExcessStrategy::ToDrain,
+            excess_strategy: ExcessStrategy::ToChange,
         }
     }
     fn knapsack_setup_output_groups(
@@ -932,7 +932,7 @@ mod test {
             cost_per_input: 20,
             cost_per_output: 10,
             min_change_value: 500,
-            excess_strategy: ExcessStrategy::ToDrain,
+            excess_strategy: ExcessStrategy::ToChange,
         }
     }
 
@@ -1333,7 +1333,7 @@ mod test {
                 cost_per_input: 20,
                 cost_per_output: 10,
                 min_change_value: (0.05 * CENT).round() as u64, // Setting minimum change value = 0.05 CENT. This will make the algorithm to avoid creating small change.
-                excess_strategy: ExcessStrategy::ToDrain,
+                excess_strategy: ExcessStrategy::ToChange,
             };
             if let Ok(result) = select_coin_knapsack(&inputs, options) {
                 // Chekcing if knapsack selects exactly 2 inputs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@ pub struct OutputGroup {
     pub weight: u32,
     /// The total number of inputs; so we can calculate extra `varint` weight due to `vin` length changes.
     pub input_count: usize,
-    /// Whether this [`OutputGroup`] contains at least one segwit spend.
-    pub is_segwit: bool,
     /// Specifies the relative creation sequence for this group, used only for FIFO selection.
     ///
     /// Set to `None` if FIFO selection is not required. Sequence numbers are arbitrary indices that denote the relative age of a UTXO group among a set of groups.
@@ -706,21 +704,18 @@ mod test {
                 value: 1000,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 2000,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 3000,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
         ]
@@ -731,28 +726,24 @@ mod test {
                 value: 1000,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(1),
             },
             OutputGroup {
                 value: 2000,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(5000),
             },
             OutputGroup {
                 value: 3000,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(1001),
             },
             OutputGroup {
                 value: 1500,
                 weight: 150,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
         ]
@@ -763,84 +754,72 @@ mod test {
                 value: 100,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 1500,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 3400,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 2200,
                 weight: 150,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 1190,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 3300,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 1000,
                 weight: 190,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 2000,
                 weight: 210,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 3000,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 2250,
                 weight: 250,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 190,
                 weight: 220,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 1750,
                 weight: 170,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
         ]
@@ -893,7 +872,6 @@ mod test {
                 value: k,
                 weight: j,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             })
         }
@@ -914,7 +892,6 @@ mod test {
                 value: k,
                 weight: j,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             })
         }
@@ -943,56 +920,48 @@ mod test {
                 value: 55000,
                 weight: 500,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 400,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 40000,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 25000,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 35000,
                 weight: 150,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 600,
                 weight: 250,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 30000,
                 weight: 120,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
             OutputGroup {
                 value: 5000,
                 weight: 50,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None,
             },
         ];
@@ -1481,35 +1450,30 @@ mod test {
                 value: 1000,
                 weight: 100,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(1),
             },
             OutputGroup {
                 value: 2000,
                 weight: 200,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None, // No sequence
             },
             OutputGroup {
                 value: 3000,
                 weight: 300,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(0), // Oldest UTXO
             },
             OutputGroup {
                 value: 1500,
                 weight: 150,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: None, // No sequence
             },
             OutputGroup {
                 value: 2500,
                 weight: 250,
                 input_count: 1,
-                is_segwit: false,
                 creation_sequence: Some(5), // Newer UTXO
             },
         ];


### PR DESCRIPTION
Simplified the coin selection process as SegWit-specific handling is no longer required.
#51 