### PR TITLE
Remove Copy trait for OutputGroup and CoinselectOption

### DIFF
--- a/examples/bitcoin_crate/src/main.rs
+++ b/examples/bitcoin_crate/src/main.rs
@@ -212,7 +212,7 @@ fn perform_select_coin(utxos: Vec<OutputGroup>, coin_select_options_vec: Vec<Coi
             "\nSelecting UTXOs to total: {:?} sats",
             coin_select_options.target_value
         );
-        match select_coin(&utxos, *coin_select_options) {
+        match select_coin(&utxos, coin_select_options.clone()) {
             Ok(selectionoutput) => {
                 println!(
                     "Selected utxo index and waste metrics are: {:?}",

--- a/examples/bitcoin_crate/src/main.rs
+++ b/examples/bitcoin_crate/src/main.rs
@@ -212,7 +212,7 @@ fn perform_select_coin(utxos: Vec<OutputGroup>, coin_select_options_vec: Vec<Coi
             "\nSelecting UTXOs to total: {:?} sats",
             coin_select_options.target_value
         );
-        match select_coin(&utxos, coin_select_options.clone()) {
+        match select_coin(&utxos, &coin_select_options) {
             Ok(selectionoutput) => {
                 println!(
                     "Selected utxo index and waste metrics are: {:?}",

--- a/src/algorithms/fifo.rs
+++ b/src/algorithms/fifo.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Returns `NoSolutionFound` if no solution is found.
 pub fn select_coin_fifo(
     inputs: &[OutputGroup],
-    options: CoinSelectionOpt,
+    options: &CoinSelectionOpt,
 ) -> Result<SelectionOutput, SelectionError> {
     let mut accumulated_value: u64 = 0;
     let mut accumulated_weight: u32 = 0;
@@ -53,7 +53,7 @@ pub fn select_coin_fifo(
         Err(SelectionError::InsufficientFunds)
     } else {
         let waste: u64 = calculate_waste(
-            &options,
+            options,
             accumulated_value,
             accumulated_weight,
             estimated_fees,
@@ -143,14 +143,14 @@ mod test {
     fn test_successful_selection() {
         let mut inputs = setup_basic_output_groups();
         let mut options = setup_options(2500);
-        let mut result = select_coin_srd(&inputs, options);
+        let mut result = select_coin_srd(&inputs, &options);
         assert!(result.is_ok());
         let mut selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
 
         inputs = setup_output_groups_withsequence();
         options = setup_options(500);
-        result = select_coin_fifo(&inputs, options);
+        result = select_coin_fifo(&inputs, &options);
         assert!(result.is_ok());
         selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
@@ -159,7 +159,7 @@ mod test {
     fn test_insufficient_funds() {
         let inputs = setup_basic_output_groups();
         let options = setup_options(7000); // Set a target value higher than the sum of all inputs
-        let result = select_coin_srd(&inputs, options);
+        let result = select_coin_srd(&inputs, &options);
         assert!(matches!(result, Err(SelectionError::InsufficientFunds)));
     }
 

--- a/src/algorithms/lowestlarger.rs
+++ b/src/algorithms/lowestlarger.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Returns `NoSolutionFound` if no solution exists.
 pub fn select_coin_lowestlarger(
     inputs: &[OutputGroup],
-    options: CoinSelectionOpt,
+    options: &CoinSelectionOpt,
 ) -> Result<SelectionOutput, SelectionError> {
     let mut accumulated_value: u64 = 0;
     let mut accumulated_weight: u32 = 0;
@@ -51,7 +51,7 @@ pub fn select_coin_lowestlarger(
         Err(SelectionError::InsufficientFunds)
     } else {
         let waste: u64 = calculate_waste(
-            &options,
+            options,
             accumulated_value,
             accumulated_weight,
             estimated_fees,
@@ -168,7 +168,7 @@ mod test {
     fn test_lowestlarger_successful() {
         let inputs = setup_lowestlarger_output_groups();
         let options = setup_options(20000);
-        let result = select_coin_lowestlarger(&inputs, options);
+        let result = select_coin_lowestlarger(&inputs, &options);
         assert!(result.is_ok());
         let selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
@@ -178,7 +178,7 @@ mod test {
     fn test_lowestlarger_insufficient() {
         let inputs = setup_lowestlarger_output_groups();
         let options = setup_options(40000);
-        let result = select_coin_lowestlarger(&inputs, options);
+        let result = select_coin_lowestlarger(&inputs, &options);
         assert!(matches!(result, Err(SelectionError::InsufficientFunds)));
     }
 }

--- a/src/algorithms/srd.rs
+++ b/src/algorithms/srd.rs
@@ -9,7 +9,7 @@ use rand::{seq::SliceRandom, thread_rng};
 /// Returns `NoSolutionFound` if no solution is found.
 pub fn select_coin_srd(
     inputs: &[OutputGroup],
-    options: CoinSelectionOpt,
+    options: &CoinSelectionOpt,
 ) -> Result<SelectionOutput, SelectionError> {
     // In out put we need to specify the indexes of the inputs in the given order
     // So keep track of the indexes when randomiz ing the vec
@@ -50,7 +50,7 @@ pub fn select_coin_srd(
         return Err(SelectionError::InsufficientFunds);
     }
     let waste = calculate_waste(
-        &options,
+        options,
         accumulated_value,
         accumulated_weight,
         estimated_fee,
@@ -141,14 +141,14 @@ mod test {
     fn test_successful_selection() {
         let mut inputs = setup_basic_output_groups();
         let mut options = setup_options(2500);
-        let mut result = select_coin_srd(&inputs, options);
+        let mut result = select_coin_srd(&inputs, &options);
         assert!(result.is_ok());
         let mut selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
 
         inputs = setup_output_groups_withsequence();
         options = setup_options(500);
-        result = select_coin_fifo(&inputs, options);
+        result = select_coin_fifo(&inputs, &options);
         assert!(result.is_ok());
         selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
@@ -157,7 +157,7 @@ mod test {
     fn test_insufficient_funds() {
         let inputs = setup_basic_output_groups();
         let options = setup_options(7000); // Set a target value higher than the sum of all inputs
-        let result = select_coin_srd(&inputs, options);
+        let result = select_coin_srd(&inputs, &options);
         assert!(matches!(result, Err(SelectionError::InsufficientFunds)));
     }
 

--- a/src/selectcoin.rs
+++ b/src/selectcoin.rs
@@ -24,7 +24,7 @@ struct SharedState {
 
 pub fn select_coin(
     inputs: &[OutputGroup],
-    options: CoinSelectionOpt,
+    options: &CoinSelectionOpt,
 ) -> Result<SelectionOutput, SelectionError> {
     let algorithms: Vec<CoinSelectionFn> = vec![
         select_coin_bnb,
@@ -42,7 +42,7 @@ pub fn select_coin(
         let best_result_clone = Arc::clone(&best_result);
         thread::scope(|s| {
             s.spawn(|| {
-                let result = algorithm(inputs, &options);
+                let result = algorithm(inputs, options);
                 let mut state = best_result_clone.lock().unwrap();
                 match result {
                     Ok(selection_output) => {
@@ -123,7 +123,7 @@ mod test {
     fn test_select_coin_successful() {
         let inputs = setup_basic_output_groups();
         let options = setup_options(1500);
-        let result = select_coin(&inputs, options);
+        let result = select_coin(&inputs, &options);
         assert!(result.is_ok());
         let selection_output = result.unwrap();
         assert!(!selection_output.selected_inputs.is_empty());
@@ -133,7 +133,7 @@ mod test {
     fn test_select_coin_insufficient_funds() {
         let inputs = setup_basic_output_groups();
         let options = setup_options(7000); // Set a target value higher than the sum of all inputs
-        let result = select_coin(&inputs, options);
+        let result = select_coin(&inputs, &options);
         assert!(matches!(result, Err(SelectionError::InsufficientFunds)));
     }
 
@@ -183,7 +183,7 @@ mod test {
         };
 
         // Call the select_coin function, which should internally use the lowest_larger algorithm
-        let selection_result = select_coin(&inputs, options).unwrap();
+        let selection_result = select_coin(&inputs, &options).unwrap();
 
         // Deterministically choose a result based on how lowest_larger would select
         let expected_inputs = vec![2]; // Example choice based on lowest_larger logic
@@ -246,7 +246,7 @@ mod test {
             excess_strategy: ExcessStrategy::ToChange,
         };
 
-        let selection_result = select_coin(&inputs, options).unwrap();
+        let selection_result = select_coin(&inputs, &options).unwrap();
 
         // Deterministically choose a result with justification
         // Here, we assume that the `select_coin` function internally chooses the most efficient set

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,7 @@
 /// For privacy reasons it might be a good choice to spend a group of UTXOs together.
 /// In the UTXO model the output of a transaction is used as the input for the new transaction and hence the name [`OutputGroup`]
 /// The library user must craft this structure correctly, as incorrect representation can lead to incorrect selection results.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct OutputGroup {
     /// Total value of the UTXO(s) that this [`WeightedValue`] represents.
     pub value: u64,
@@ -23,7 +23,7 @@ pub struct OutputGroup {
 }
 
 /// Options required to compute fees and waste metric.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct CoinSelectionOpt {
     /// The value we need to select.
     pub target_value: u64,
@@ -66,7 +66,7 @@ pub struct CoinSelectionOpt {
 }
 
 /// Strategy to decide what to do with the excess amount.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExcessStrategy {
     ToFee,
     ToRecipient,


### PR DESCRIPTION
The values are types are only read throughout the codebase and are not changed at all.
They take significant space and it is inefficient to copy them through function calls especially in bnb which uses recursion.

Scoped threads simplify using references rather than cloning.